### PR TITLE
사용자의 습관 목록을 불러오는 기능을 개발했습니다.

### DIFF
--- a/src/main/java/com/example/backend/Habit/controller/HabitController.java
+++ b/src/main/java/com/example/backend/Habit/controller/HabitController.java
@@ -3,6 +3,7 @@ package com.example.backend.Habit.controller;
 import com.example.backend.Habit.dto.HabitCheckCountDTO;
 import com.example.backend.Habit.dto.HabitCheckRequestDTO;
 import com.example.backend.Habit.dto.HabitCreateResponseDTO;
+import com.example.backend.Habit.dto.MyHabitInfoDTO;
 import com.example.backend.Habit.mapper.MyHabitMapper;
 import com.example.backend.Habit.service.HabitService;
 import com.example.backend.Habit.service.HabitServieImp;
@@ -21,10 +22,11 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+
 @Slf4j
 @RestController
 @RequestMapping("/habits")
-@CrossOrigin(origins = "http://localhost:5173")
 public class HabitController {
 
   private final HabitService habitService;
@@ -41,6 +43,28 @@ public class HabitController {
   public ResponseEntity<List<MyHabitVO>> getMyHabit(@RequestParam("userId") long userId) {
     try {
       List<MyHabitVO> habits = habitService.getMyHabit(userId);
+      log.info("(1) Successfully retrieved my habits.");
+      return ResponseEntity.ok(habits);
+    } catch (UnauthorizedException e) {
+      log.info("401 Unauthorized: {}", e.getMessage());
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+    } catch (NotFoundException e) {
+      log.info("404 Not Found: {}", e.getMessage());
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+    } catch (InternalServerErrorException e) {
+      log.info("500 Internal Server Error: {}", e.getMessage());
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+    }
+  }
+
+  @CrossOrigin(origins = "http://localhost:5173")
+  @PostMapping("/my-today-info")
+  public ResponseEntity<List<MyHabitInfoDTO>> getMyHabitInfo(@RequestBody Map<String, Long> request) {
+    log.info("(1) Successfully retrieved my habits. 습관불러오기요청");
+    try {
+      long userId = request.get("userId");
+      List<MyHabitInfoDTO> habits = habitService.getMyTodayHabitInfo(userId);
+      log.info("habits: {}", habits);
       log.info("(1) Successfully retrieved my habits.");
       return ResponseEntity.ok(habits);
     } catch (UnauthorizedException e) {

--- a/src/main/java/com/example/backend/Habit/dto/MyHabitInfoDTO.java
+++ b/src/main/java/com/example/backend/Habit/dto/MyHabitInfoDTO.java
@@ -1,0 +1,21 @@
+package com.example.backend.Habit.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class MyHabitInfoDTO {
+    private Long myHabitId;
+    private Long habitId;
+    private Long writerId;
+    private String habitTitle;
+    private String categoryTitle;
+    private String state;
+//    private Date checkDate;
+    private Long saveAmount;
+    private String certification;
+    private String isCheckedToday;
+}

--- a/src/main/java/com/example/backend/Habit/mapper/MyHabitMapper.java
+++ b/src/main/java/com/example/backend/Habit/mapper/MyHabitMapper.java
@@ -1,5 +1,6 @@
 package com.example.backend.Habit.mapper;
 
+import com.example.backend.Habit.dto.MyHabitInfoDTO;
 import com.example.backend.Habit.vo.HabitCheckVO;
 import com.example.backend.Habit.vo.MyHabitVO;
 import com.example.backend.HabitCommunity.vo.HabitCommunityVO;
@@ -17,6 +18,8 @@ public interface MyHabitMapper {
   // 2. 기존에 있는 습관인지 조회
   MyHabitVO getHabitByTitle(@Param("habitTitle") String habitTitle);
 
+
+  List<MyHabitInfoDTO> getMyTodayHabitInfo(@Param("userId") long userId);
 
   // 4. 새로운 습관 작성
   void insertHabit(MyHabitVO myHabitVO);     // step 1 : Habit 테이블에 습관 삽입

--- a/src/main/java/com/example/backend/Habit/service/HabitService.java
+++ b/src/main/java/com/example/backend/Habit/service/HabitService.java
@@ -3,6 +3,7 @@ package com.example.backend.Habit.service;
 import com.example.backend.Habit.dto.HabitCheckCountDTO;
 import com.example.backend.Habit.dto.HabitCheckRequestDTO;
 import com.example.backend.Habit.dto.HabitCreateResponseDTO;
+import com.example.backend.Habit.dto.MyHabitInfoDTO;
 import com.example.backend.Habit.vo.HabitCheckVO;
 import com.example.backend.Habit.vo.MyHabitVO;
 import com.example.backend.HabitCommunity.vo.HabitCommunityVO;
@@ -16,6 +17,8 @@ import java.util.List;
 public interface HabitService {
   // 1. 나의 습관 조회
   List<MyHabitVO> getMyHabit(@Param("userId") long userId);
+
+  List<MyHabitInfoDTO> getMyTodayHabitInfo(@Param("userId") long userId);
 
   // 2. 습관 달성 체크
   void addHabitChecked(HabitCheckVO habitCheckVO);

--- a/src/main/java/com/example/backend/Habit/service/HabitServieImp.java
+++ b/src/main/java/com/example/backend/Habit/service/HabitServieImp.java
@@ -3,6 +3,7 @@ package com.example.backend.Habit.service;
 import com.example.backend.Habit.dto.HabitCheckCountDTO;
 import com.example.backend.Habit.dto.HabitCheckRequestDTO;
 import com.example.backend.Habit.dto.HabitCreateResponseDTO;
+import com.example.backend.Habit.dto.MyHabitInfoDTO;
 import com.example.backend.Habit.mapper.HabitCheckMapper;
 import com.example.backend.Habit.mapper.MyHabitMapper;
 import com.example.backend.Habit.vo.HabitCheckVO;
@@ -30,6 +31,11 @@ public class HabitServieImp implements HabitService {
     @Override
     public List<MyHabitVO> getMyHabit(long userId) {
         return myHabitMapper.getMyHabit(userId);
+    }
+
+    @Override
+    public List<MyHabitInfoDTO> getMyTodayHabitInfo(long userId) {
+        return myHabitMapper.getMyTodayHabitInfo(userId);
     }
 
     // 2. 습관 달성 체크

--- a/src/main/java/com/example/backend/config/WebConfig.java
+++ b/src/main/java/com/example/backend/config/WebConfig.java
@@ -77,12 +77,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
+                .maxAge(3600);
     }
-
-
 }
 

--- a/src/main/resources/mapper/MyHabitMapper.xml
+++ b/src/main/resources/mapper/MyHabitMapper.xml
@@ -19,6 +19,20 @@
         WHERE habit_title = #{habitTitle};
     </select>
 
+    <!-- 유저 전체 습관 목록과 오늘 습관 달성 체크 여부 -->
+    <select id="getMyTodayHabitInfo" parameterType="long" resultType="com.example.backend.Habit.dto.MyHabitInfoDTO">
+        SELECT mh.my_habit_id, h.user_id AS writer_id, mh.state, h.save_amount, h.certification, h.habit_id, h.habit_title, h.category_title,
+               CASE
+                   WHEN hc.my_habit_id IS NOT NULL
+                       THEN 'true' ELSE 'false'
+                   END AS is_checked_today
+        FROM MyHabit mh
+                 JOIN HABIT h ON mh.habit_id = h.habit_id
+                 left join HabitCheck hc ON mh.my_habit_id = hc.my_habit_id
+            AND hc.check_date = CURDATE()
+        WHERE mh.user_id = #{userId};
+    </select>
+
     <!-- 4. 새로운 습관 작성 -->
     <!-- step 1 : Habit 테이블에 습관 삽입 -->
     <insert id="insertHabit" parameterType="MyHabitVO">

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -13,6 +13,7 @@
         <package name="com.example.backend.HabitCheck.vo"/>
         <package name="com.example.backend.HabitCommunity.vo"/>
         <package name="com.example.backend.MyHabit.vo"/>
+        <package name="com.example.backend.Habit.dto.MyHabitInfoDTO"/>
         <package name="com.example.backend.PostComment.vo"/>
         <package name="com.example.backend.PostLikes.vo"/>
         <package name="com.example.backend.PostCommunity.vo"/>


### PR DESCRIPTION
### 설명
- 프론트 전역에서 사용하는 데이터를 불러오는 로직입니다.
- 로그인 직후 메인화면이 등장할 때 갱신하며,
- 습관 데이터를 관여하는 상황 (습관 인증하기, 편집하기, 추가하기) 상황에서 사용을 권장합니다.

### 요청 내용
- my habit id
- habit id
- 작성자 id
- 습관 제목
- 카테고리 제목
- 상태('대기' or '진행')
- 절약 추정액
- 인증 방법
- 오늘 체크 여부('true' or 'false')

### 사용방법
- `http://localhost:8080/habits/my-today-info`
- POST
- JSON
   ```
    {
     "userId": "1"
    }
  ``` 